### PR TITLE
Add gamma_min/max as kwargs

### DIFF
--- a/changelog/60.feature.rst
+++ b/changelog/60.feature.rst
@@ -1,0 +1,1 @@
+The minimum and maximum values of the gamma transform can now be specified for :func:`sunkit_image.enhance.mgn`.

--- a/sunkit_image/enhance.py
+++ b/sunkit_image/enhance.py
@@ -8,7 +8,8 @@ import scipy.ndimage as ndimage
 __all__ = ["mgn"]
 
 
-def mgn(data, sigma=[1.25, 2.5, 5, 10, 20, 40], k=0.7, gamma=3.2, h=0.7, weights=None, truncate=3, clip=True):
+def mgn(data, sigma=[1.25, 2.5, 5, 10, 20, 40], k=0.7, gamma=3.2, h=0.7, weights=None, truncate=3, clip=True,
+        gamma_min=None, gamma_max=None):
     """
     Multi-scale Gaussian normalization.
 
@@ -40,6 +41,10 @@ def mgn(data, sigma=[1.25, 2.5, 5, 10, 20, 40], k=0.7, gamma=3.2, h=0.7, weights
         The value used to calculate the global gamma-transformed image.
         Ideally should be between 2.5 to 4 according to the paper.
         Defaults to 3.2.
+    gamma_min : `float`, optional
+        Minimum input to the gamma transform. Defaults to minimum value of `data`
+    gamma_max : `float`, optional
+        Maximum input to the gamma transform. Defaults to maximum value of `data`
     h : `float`, optional
         Weight of global filter to Gaussian filters.
         Defaults to 0.7.
@@ -111,11 +116,11 @@ def mgn(data, sigma=[1.25, 2.5, 5, 10, 20, 40], k=0.7, gamma=3.2, h=0.7, weights
 
     # 9. Calculate global gamma-transformed image C'g
     # Refer to equation (4) in the paper
-    data_min = data.min()
-    data_max = data.max()
-    Cprime_g = data - data_min
-    if (data_max - data_min) != 0.0:
-        Cprime_g /= data_max - data_min
+    gamma_min = data.min() if gamma_min is None else gamma_min
+    gamma_max = data.max() if gamma_max is None else gamma_max
+    Cprime_g = data - gamma_min
+    if (gamma_max - gamma_min) != 0.0:
+        Cprime_g /= gamma_max - gamma_min
     Cprime_g **= 1 / gamma
     Cprime_g *= h
 


### PR DESCRIPTION
<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

In the IDL implementation (see https://solarphysics.aber.ac.uk/mgn.pro), the minimum and maximum values for the gamma-transform, called `a0` and `a1`, are input arguments. However, in this translation, they are fixed as the min and max values of the image. This PR makes them arguments that default to the min and max of the image. This should probably include a test for non-None values of these kwargs...