### PR TITLE
Add two coalignment examples

### DIFF
--- a/changelog/90.feature.rst
+++ b/changelog/90.feature.rst
@@ -1,0 +1,1 @@
+Add two examples demonstrating the usage of :func:`~sunkit_image.coalignment.mapsequence_coalign_by_match_template` and :func:`~sunkit_image.coalignment.mapsequence_coalign_by_rotation`.

--- a/examples/mapsequence_coalignment.py
+++ b/examples/mapsequence_coalignment.py
@@ -17,18 +17,24 @@ of the image processing library
 `scikit-image <https://scikit-image.org/docs/stable/install.html>`__.
 """
 import matplotlib.pyplot as plt
+
 import sunpy.data.sample
-from sunkit_image import coalignment
 from sunpy.map import Map
+
+from sunkit_image import coalignment
 
 ###############################################################################
 # Create a `~sunpy.map.MapSequence` using sample data.
-mc = Map([sunpy.data.sample.AIA_193_CUTOUT01_IMAGE,
-          sunpy.data.sample.AIA_193_CUTOUT02_IMAGE,
-          sunpy.data.sample.AIA_193_CUTOUT03_IMAGE,
-          sunpy.data.sample.AIA_193_CUTOUT04_IMAGE,
-          sunpy.data.sample.AIA_193_CUTOUT05_IMAGE],
-         sequence=True)
+mc = Map(
+    [
+        sunpy.data.sample.AIA_193_CUTOUT01_IMAGE,
+        sunpy.data.sample.AIA_193_CUTOUT02_IMAGE,
+        sunpy.data.sample.AIA_193_CUTOUT03_IMAGE,
+        sunpy.data.sample.AIA_193_CUTOUT04_IMAGE,
+        sunpy.data.sample.AIA_193_CUTOUT05_IMAGE,
+    ],
+    sequence=True,
+)
 
 ###############################################################################
 # Plot an animation of the `~sunpy.map.MapSequence` that we can compare with

--- a/examples/mapsequence_coalignment.py
+++ b/examples/mapsequence_coalignment.py
@@ -1,0 +1,72 @@
+"""
+================================================
+Coalignment of MapSequences by Template Matching
+================================================
+
+A common approach to coaligning a time series of images is to take a
+representative template that contains the features you are interested in, and
+match that to your images. The location of the best match tells you where the
+template is in your image. The images are then shifted to the location of the
+best match. This aligns your images to the position of the features in your
+representative template.
+
+This example demonstrates how to coalign maps in a `~sunpy.MapSequence` using
+the :func:`~sunkit_image.coalignment.mapsequence_coalign_by_match_template`
+function. The implementation of this functionality requires the installation
+of the image processing library
+`scikit-image <https://scikit-image.org/docs/stable/install.html>`__.
+"""
+import matplotlib.pyplot as plt
+import sunpy.data.sample
+from sunkit_image import coalignment
+from sunpy.map import Map
+
+###############################################################################
+# Create a `~sunpy.map.MapSequence` using sample data.
+mc = Map([sunpy.data.sample.AIA_193_CUTOUT01_IMAGE,
+          sunpy.data.sample.AIA_193_CUTOUT02_IMAGE,
+          sunpy.data.sample.AIA_193_CUTOUT03_IMAGE,
+          sunpy.data.sample.AIA_193_CUTOUT04_IMAGE,
+          sunpy.data.sample.AIA_193_CUTOUT05_IMAGE],
+         sequence=True)
+
+###############################################################################
+# Plot an animation of the `~sunpy.map.MapSequence` that we can compare with
+# the coaligned MapSequence.
+plt.figure()
+anim = mc.plot()
+plt.show()
+
+###############################################################################
+# To coalign the `~sunpy.map.MapSequence`, apply the
+# :func:`~sunkit_image.coalignment.mapsequence_coalign_by_match_template`
+# function.
+coaligned = coalignment.mapsequence_coalign_by_match_template(mc)
+
+###############################################################################
+# This returns a new `~sunpy.map.MapSequence` coaligned to a template
+# extracted from the center of the first map in the `~sunpy.map.MapSequence`,
+# with the dimensions clipped as required.
+#
+# For a full list of options and functionality of the coalignment algorithm,
+# see `~sunkit_image.coalignment.mapsequence_coalign_by_match_template`.
+#
+# Now, let's plot an animation of the coaligned MapSequence to compare with
+# the original.
+plt.figure()
+anim_coalign = coaligned.plot()
+plt.show()
+
+###############################################################################
+# If you just want to calculate the shifts required to compensate for solar
+# rotation relative to the first map in the `~sunpy.map.MapSequence` without
+# applying the shifts, use
+# :func:`~sunkit_image.coalignment.calculate_match_template_shift`:
+shifts = coalignment.calculate_match_template_shift(mc)
+
+###############################################################################
+# This is the function used to calculate the shifts in
+# :func:`~sunkit_image.coalignment.mapsequence_coalign_by_match_template`.
+# The shifts calculated here can be passed directly to the coalignment
+# function.
+coaligned = coalignment.mapsequence_coalign_by_match_template(mc, shift=shifts)

--- a/examples/mapsequence_solar_rotation.py
+++ b/examples/mapsequence_solar_rotation.py
@@ -1,0 +1,67 @@
+"""
+===============================================
+Compensating for Solar Rotation in MapSequences
+===============================================
+
+Often a set of solar image data consists of fixing the pointing of a field of
+view for some time and observing. Features on the Sun will differentially
+rotate depending on latitude, with features at the equator moving faster than
+features at the poles.
+
+In this example, the process of shifting images in a `~sunpy.map.MapSequence`
+to account for the differential rotation of the Sun is demonstrated using the
+:func:`~sunkit_image.coalignment.mapsequence_coalign_by_rotation` function.
+"""
+import matplotlib.pyplot as plt
+import sunpy.data.sample
+from sunkit_image import coalignment
+from sunpy.map import Map
+
+###############################################################################
+# First, create a `~sunpy.map.MapSequence` with sample data.
+mc = Map([sunpy.data.sample.AIA_193_CUTOUT01_IMAGE,
+          sunpy.data.sample.AIA_193_CUTOUT02_IMAGE,
+          sunpy.data.sample.AIA_193_CUTOUT03_IMAGE,
+          sunpy.data.sample.AIA_193_CUTOUT04_IMAGE,
+          sunpy.data.sample.AIA_193_CUTOUT05_IMAGE],
+         sequence=True)
+
+###############################################################################
+# Let's plot the MapSequence so we can later compare it with the shifted
+# result.
+plt.figure()
+anim = mc.plot()
+plt.show()
+
+###############################################################################
+# The :func:`~sunkit_image.coalignment.mapsequence_coalign_by_rotation`
+# function can be applied to the Map Sequence
+derotated = coalignment.mapsequence_coalign_by_rotation(mc)
+
+###############################################################################
+# By default, the de-rotation shifts are calculated relative to the first map
+# in the `~sunpy.map.MapSequence`.
+# This function does not differentially rotate the image (see
+# `Differentially rotating a map <https://docs.sunpy.org/en/stable/generated/gallery/differential_rotation/reprojected_map.html>`__
+# for an example). It is useful for de-rotating images when the effects of
+# differential rotation in the `~sunpy.map.MapSequence` can be ignored.
+#
+# See the docstring of
+# :func:`~sunkit_image.coalignment.mapsequence_coalign_by_rotation`
+# for more features of the function.
+#
+# To check that the applied shifts were reasonable, plot an animation of the
+# shifted MapSequence to compare with the original plot above.
+plt.figure()
+anim_derotate = derotated.plot()
+plt.show()
+
+###############################################################################
+# The de-rotation shifts used in the above function can be calculated without
+# applying them using the
+# :func:`~sunkit_image.coalignment.calculate_solar_rotate_shift` function.
+shifts = coalignment.calculate_solar_rotate_shift(mc)
+
+###############################################################################
+# The calculated shifts can be passed as an argument to
+# :func:`~sunkit_image.coalignment.mapsequence_coalign_by_rotation`.

--- a/examples/mapsequence_solar_rotation.py
+++ b/examples/mapsequence_solar_rotation.py
@@ -13,18 +13,24 @@ to account for the differential rotation of the Sun is demonstrated using the
 :func:`~sunkit_image.coalignment.mapsequence_coalign_by_rotation` function.
 """
 import matplotlib.pyplot as plt
+
 import sunpy.data.sample
-from sunkit_image import coalignment
 from sunpy.map import Map
+
+from sunkit_image import coalignment
 
 ###############################################################################
 # First, create a `~sunpy.map.MapSequence` with sample data.
-mc = Map([sunpy.data.sample.AIA_193_CUTOUT01_IMAGE,
-          sunpy.data.sample.AIA_193_CUTOUT02_IMAGE,
-          sunpy.data.sample.AIA_193_CUTOUT03_IMAGE,
-          sunpy.data.sample.AIA_193_CUTOUT04_IMAGE,
-          sunpy.data.sample.AIA_193_CUTOUT05_IMAGE],
-         sequence=True)
+mc = Map(
+    [
+        sunpy.data.sample.AIA_193_CUTOUT01_IMAGE,
+        sunpy.data.sample.AIA_193_CUTOUT02_IMAGE,
+        sunpy.data.sample.AIA_193_CUTOUT03_IMAGE,
+        sunpy.data.sample.AIA_193_CUTOUT04_IMAGE,
+        sunpy.data.sample.AIA_193_CUTOUT05_IMAGE,
+    ],
+    sequence=True,
+)
 
 ###############################################################################
 # Let's plot the MapSequence so we can later compare it with the shifted


### PR DESCRIPTION
This pull request adds two examples to the example gallery that are adapted from the current [sunpy Map guide](https://docs.sunpy.org/en/stable/guide/data_types/maps.html). Specifically, the sections on coaligning MapSequences (template matching and solar rotation) have been re-written due to the deprecation of `sunpy.image.coalignment` and `sunpy.physics.solar_rotation` (see PR #81). This PR is also in response to a conversation on https://github.com/sunpy/sunpy/pull/6345 that will lead to the removal of the relevant sections from the Map Guide.
