### PR TITLE
Reduce API toctree levels

### DIFF
--- a/docs/code_ref/index.rst
+++ b/docs/code_ref/index.rst
@@ -5,7 +5,7 @@ API Reference
 *************
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    asda
    coalignment


### PR DESCRIPTION
With two levels it's not very readable (see below), so reduce to one level
<img width="306" alt="Screenshot 2023-03-15 at 10 06 09" src="https://user-images.githubusercontent.com/6197628/225276557-bb4218be-0c0f-49e6-ac97-b8a1bdf0db5d.png">
