### PR TITLE
Improve example gallery titles

### DIFF
--- a/examples/mapsequence_coalignment.py
+++ b/examples/mapsequence_coalignment.py
@@ -1,7 +1,7 @@
 """
-================================================
-Coalignment of MapSequences by Template Matching
-================================================
+===================================
+Coalignment using Template Matching
+===================================
 
 A common approach to coaligning a time series of images is to take a
 representative template that contains the features you are interested in, and

--- a/examples/mapsequence_solar_rotation.py
+++ b/examples/mapsequence_solar_rotation.py
@@ -1,7 +1,7 @@
 """
-===============================================
-Compensating for Solar Rotation in MapSequences
-===============================================
+===============================
+Compensating for Solar Rotation
+===============================
 
 Often a set of solar image data consists of fixing the pointing of a field of
 view for some time and observing. Features on the Sun will differentially

--- a/examples/tracing_loops.py
+++ b/examples/tracing_loops.py
@@ -1,6 +1,6 @@
 """
 =====================
-Coronal Loops Tracing
+Tracing Coronal Loops
 =====================
 
 This example traces out the coronal loops in a FITS image


### PR DESCRIPTION
A few minor improvements to titles, in particular removing `MapSequence` as that's a technical implementation detail. 