### PR TITLE
removed marks from fixtures in tests

### DIFF
--- a/sunkit_image/tests/conftest.py
+++ b/sunkit_image/tests/conftest.py
@@ -155,7 +155,6 @@ def granule_minimap3():
 
 
 @pytest.fixture(params=["array", "map"])
-@pytest.mark.remote_data()
 def aia_171(request):
     smap = sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
     if request.param == "map":

--- a/sunkit_image/tests/test_radial.py
+++ b/sunkit_image/tests/test_radial.py
@@ -167,7 +167,6 @@ def test_fnrgf(map_test1, map_test2, radial_bin_edges):
 
 
 @pytest.fixture()
-@pytest.mark.remote_data()
 def smap():
     return sunpy.map.Map(sunpy.data.sample.AIA_171_IMAGE)
 

--- a/sunkit_image/tests/test_trace.py
+++ b/sunkit_image/tests/test_trace.py
@@ -20,7 +20,6 @@ from sunkit_image.trace import (
 
 
 @pytest.fixture(params=["array", "map"])
-@pytest.mark.remote_data()
 def image_remote(request):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=fits.verify.VerifyWarning)

--- a/sunkit_image/utils/tests/test_utils.py
+++ b/sunkit_image/utils/tests/test_utils.py
@@ -11,7 +11,6 @@ from sunkit_image.data.test import get_test_filepath
 
 
 @pytest.fixture()
-@pytest.mark.remote_data()
 def smap():
     import sunpy.data.sample
     from sunpy.data.sample import AIA_171_IMAGE


### PR DESCRIPTION
pytest deprecated the usage of marks with fixtures. so I removed the marks from fixtures and made sure that the marks are in the right place.