### PR TITLE
removed the xfail mark

### DIFF
--- a/sunkit_image/tests/test_enhance.py
+++ b/sunkit_image/tests/test_enhance.py
@@ -21,7 +21,6 @@ def map_test():
     return np.ones((4, 4), dtype=float)
 
 
-@pytest.mark.xfail()
 def test_multiscale_gaussian(map_test):
     # Assuming the algorithm works fine then the below two should be equal.
     expect1 = enhance.mgn(map_test, [1])


### PR DESCRIPTION
## PR Description
This pull request aims to assess whether removing "xfail" results in the failure of the mgn unit test within the CI.
Related to #96 
Also since this is an internal test, changelog won't be required