### PR TITLE
expanding tracing example to extract intensities

### DIFF
--- a/examples/tracing_loops.py
+++ b/examples/tracing_loops.py
@@ -1,19 +1,18 @@
 """
-=====================
+================================================
 Tracing Coronal Loops and Extracting Intensities
-=====================
+================================================
 
 This example traces out the coronal loops in a FITS image
-using `~sunkit_image.trace.occult2` and then extracts the intensities
-along the traced loops.
+using `~sunkit_image.trace.occult2` and then extracts the intensity
+along one traced loop.
 
 In this example we will use the settings and the data from Markus Aschwanden's tutorial
 on his IDL implementation of the ``OCCULT2`` algorithm, which can be found
 `here <http://www.lmsal.com/~aschwand/software/tracing/tracing_tutorial1.html>`__.
 
-The aim of this example is to demonstrate that `~sunkit_image.trace.occult2` provides similar
-results compared to the IDL version and how to extract intensities along the traced loops.
 """
+# sphinx_gallery_thumbnail_number = 1  # NOQA: ERA001
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -72,30 +71,29 @@ for loop in loops:
 fig.tight_layout()
 
 ###############################################################################
-# Now, let's extract the intensities along the first detected loop and plot the intensity profile.
+# Finally, we can use the traced loops location information to extract the intensity values.
 
-# Convert the first loop to SkyCoord objects
+# Since we only currently get pixel locations, we need to get the word coordinates of the first loop.
 first_loop = np.array(loops[0])
-intensity_coords = trace_map.pixel_to_world(first_loop[:, 0] * u.pixel, first_loop[:, 1] * u.pixel)
+loop_coords = trace_map.pixel_to_world(first_loop[:, 0] * u.pixel, first_loop[:, 1] * u.pixel)
 
-# Sample the intensity along the loop
-intensity = sunpy.map.sample_at_coords(trace_map, intensity_coords)
+# Now we can extract the intensity along the loop
+intensity = sunpy.map.sample_at_coords(trace_map, loop_coords)
 
-# Calculate the angular separation along the loop
-angular_separation = intensity_coords.separation(intensity_coords[0]).to(u.arcsec)
+# Finally, we can calculate the angular separation along the loop
+angular_separation = loop_coords.separation(loop_coords[0]).to(u.arcsec)
 
-# Plot the intensity profile
-fig2 = plt.figure(figsize=(10, 4))
-ax2 = fig2.add_subplot(121, projection=trace_map)
-trace_map.plot(axes=ax2, clip_interval=(1, 99.99) * u.percent)
-ax2.plot_coord(intensity_coords, color="r")
-ax2.plot_coord(intensity_coords[0], marker="o", color="blue", label="start")
-ax2.plot_coord(intensity_coords[-1], marker="o", color="green", label="end")
-ax2.legend()
+# Plot the loop location and its intensity profile
+fig = plt.figure(figsize=(10, 4))
+ax = fig.add_subplot(121, projection=trace_map)
+trace_map.plot(axes=ax, clip_interval=(1, 99.99) * u.percent)
+ax.plot_coord(loop_coords, color="r")
 
-ax3 = fig2.add_subplot(122)
-ax3.plot(angular_separation, intensity)
-ax3.set_xlabel("Angular distance along loop [arcsec]")
-ax3.set_ylabel(f"Intensity [{trace_map.unit}]")
+ax = fig.add_subplot(122)
+ax.plot(angular_separation, intensity)
+ax.set_xlabel("Distance along loop [Arcsec]")
+ax.set_ylabel("Intensity")
+
+fig.tight_layout()
 
 plt.show()

--- a/examples/tracing_loops.py
+++ b/examples/tracing_loops.py
@@ -1,17 +1,18 @@
 """
 =====================
-Tracing Coronal Loops
+Tracing Coronal Loops and Extracting Intensities
 =====================
 
 This example traces out the coronal loops in a FITS image
-using `~sunkit_image.trace.occult2`.
+using `~sunkit_image.trace.occult2` and then extracts the intensities
+along the traced loops.
 
 In this example we will use the settings and the data from Markus Aschwanden's tutorial
 on his IDL implementation of the ``OCCULT2`` algorithm, which can be found
 `here <http://www.lmsal.com/~aschwand/software/tracing/tracing_tutorial1.html>`__.
 
 The aim of this example is to demonstrate that `~sunkit_image.trace.occult2` provides similar
-results compared to the IDL version.
+results compared to the IDL version and how to extract intensities along the traced loops.
 """
 
 import matplotlib.pyplot as plt
@@ -69,5 +70,32 @@ for loop in loops:
     ax.plot_coord(coord_loops, color="b")
 
 fig.tight_layout()
+
+###############################################################################
+# Now, let's extract the intensities along the first detected loop and plot the intensity profile.
+
+# Convert the first loop to SkyCoord objects
+first_loop = np.array(loops[0])
+intensity_coords = trace_map.pixel_to_world(first_loop[:, 0] * u.pixel, first_loop[:, 1] * u.pixel)
+
+# Sample the intensity along the loop
+intensity = sunpy.map.sample_at_coords(trace_map, intensity_coords)
+
+# Calculate the angular separation along the loop
+angular_separation = intensity_coords.separation(intensity_coords[0]).to(u.arcsec)
+
+# Plot the intensity profile
+fig2 = plt.figure(figsize=(10, 4))
+ax2 = fig2.add_subplot(121, projection=trace_map)
+trace_map.plot(axes=ax2, clip_interval=(1, 99.99) * u.percent)
+ax2.plot_coord(intensity_coords, color="r")
+ax2.plot_coord(intensity_coords[0], marker="o", color="blue", label="start")
+ax2.plot_coord(intensity_coords[-1], marker="o", color="green", label="end")
+ax2.legend()
+
+ax3 = fig2.add_subplot(122)
+ax3.plot(angular_separation, intensity)
+ax3.set_xlabel("Angular distance along loop [arcsec]")
+ax3.set_ylabel(f"Intensity [{trace_map.unit}]")
 
 plt.show()


### PR DESCRIPTION

## PR Description

This pull request enhances the existing example for tracing coronal loops using ``~sunkit_image.trace.occult2`` by adding functionality to extract and plot the intensity profiles along the traced loops. The primary goal is to demonstrate how to use the ``SkyCoord`` objects obtained from the tracing process to extract and visualize intensity profiles along the traced loops.

## Key Changes

1. **Tracing Coronal Loops:** The first part of the code remains the same, where we trace coronal loops using the occult2 function.
2. **Plotting Detected Loops:** The detected loops are plotted on the original image.
3. **Extracting Intensities:** The new part of the code extracts the intensities along the first detected loop. This is done by converting the loop's pixel coordinates to SkyCoord objects and then sampling the intensity along these coordinates.
4. **Plotting Intensity Profile:** The intensity profile along the loop is plotted in a separate subplot, showing the intensity vs. angular distance.

## Related Issues

This fixes #198 

![Screenshot 2024-11-10 234904](https://github.com/user-attachments/assets/814fd999-1fbf-4b46-91f7-835c63330027)
