### PR TITLE
Rhe ignore nans

### DIFF
--- a/changelog/254.breaking.rst
+++ b/changelog/254.breaking.rst
@@ -1,0 +1,1 @@
+Removed "inplace" method for `sunkit_image.radial.rhef`.

--- a/changelog/254.bugfix.rst
+++ b/changelog/254.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed NaN handling in `sunkit_image.radial.rhef`.

--- a/sunkit_image/radial.py
+++ b/sunkit_image/radial.py
@@ -102,16 +102,17 @@ def _normalize_fit_radial_intensity(radii, polynomial, normalization_radius):
 
 def _select_rank_method(method):
     # For now, we have more than one option for ranking the values
-    def _percentile_ranks_scipy(arr):
+    def _percentile_ranks_scipy(arr):   
         from scipy import stats
 
         return stats.rankdata(arr, method="average") / len(arr)
 
     def _percentile_ranks_numpy(arr):
+        ranks = arr.copy()
         sorted_indices = np.argsort(arr)
-        ranks = np.empty_like(sorted_indices)
-        ranks[sorted_indices] = np.arange(1, len(arr) + 1)
-        return ranks / float(len(arr))
+        sorted_indices =sorted_indices[~np.isnan(arr[sorted_indices])]
+        ranks[sorted_indices] = np.arange(1, len(sorted_indices) + 1)
+        return ranks / float(len(sorted_indices))
 
     def _percentile_ranks_numpy_inplace(arr):
         sorted_indices = np.argsort(arr)
@@ -731,6 +732,7 @@ def rhef(
         if application_radius is not None and application_radius > 0:
             here = np.logical_and(here, map_r >= application_radius)
         # Apply ranking function
+         
         data[here] = ranking_func(smap.data[here])
         if upsilon is not None:
             data[here] = apply_upsilon(data[here], upsilon)

--- a/sunkit_image/radial.py
+++ b/sunkit_image/radial.py
@@ -102,7 +102,7 @@ def _normalize_fit_radial_intensity(radii, polynomial, normalization_radius):
 
 def _select_rank_method(method):
     # For now, we have more than one option for ranking the values
-    def _percentile_ranks_scipy(arr):   
+    def _percentile_ranks_scipy(arr):
         from scipy import stats
 
         return stats.rankdata(arr, method="average") / len(arr)
@@ -110,7 +110,7 @@ def _select_rank_method(method):
     def _percentile_ranks_numpy(arr):
         ranks = arr.copy()
         sorted_indices = np.argsort(arr)
-        sorted_indices =sorted_indices[~np.isnan(arr[sorted_indices])]
+        sorted_indices = sorted_indices[~np.isnan(arr[sorted_indices])]
         ranks[sorted_indices] = np.arange(1, len(sorted_indices) + 1)
         return ranks / float(len(sorted_indices))
 
@@ -732,7 +732,6 @@ def rhef(
         if application_radius is not None and application_radius > 0:
             here = np.logical_and(here, map_r >= application_radius)
         # Apply ranking function
-         
         data[here] = ranking_func(smap.data[here])
         if upsilon is not None:
             data[here] = apply_upsilon(data[here], upsilon)


### PR DESCRIPTION

## PR Adds a bug fix to address sunkit-image issue #253.  This will remove the NAN values from the ranking calculations, and the nan's values will be replaced with new ranks.

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->

Fixes #253 
