### PR TITLE
Update radial.py to include "none" as an option for rhef

### DIFF
--- a/changelog/266.breaking.rst
+++ b/changelog/266.breaking.rst
@@ -1,0 +1,1 @@
+Changed the default rank method for `sunkit_image.radial.rhef` from 'numpy' to 'scipy'.

--- a/changelog/266.feature.rst
+++ b/changelog/266.feature.rst
@@ -1,0 +1,1 @@
+Added a method called "none" to `sunkit_image.radial.rhef` to allow for the bypassing of the radial filter.

--- a/sunkit_image/radial.py
+++ b/sunkit_image/radial.py
@@ -118,6 +118,11 @@ def _select_rank_method(method):
         arr[sorted_indices] = np.arange(1, len(arr) + 1)
         return arr / float(len(arr))
 
+    def _pass_without_filtering(arr):
+        return arr
+
+    method = str(method).casefold()
+    
     # Select the sort method
     if method == "inplace":
         ranking_func = _percentile_ranks_numpy_inplace
@@ -125,8 +130,10 @@ def _select_rank_method(method):
         ranking_func = _percentile_ranks_numpy
     elif method == "scipy":
         ranking_func = _percentile_ranks_scipy
+    elif method == "none":
+        ranking_func = _pass_without_filtering
     else:
-        msg = f"{method} is invalid. Allowed values are 'inplace', 'numpy', 'scipy'"
+        msg = f"{method} is invalid. Allowed values are 'inplace', 'numpy', 'scipy', or 'none'"
         raise NotImplementedError(msg)
     return ranking_func
 
@@ -651,7 +658,7 @@ def rhef(
     radial_bin_edges=None,
     application_radius=0 * u.R_sun,
     upsilon=0.35,
-    method="numpy",
+    method="scipy",
     vignette=None,
     progress=False,
     fill=np.nan,

--- a/sunkit_image/radial.py
+++ b/sunkit_image/radial.py
@@ -121,9 +121,7 @@ def _select_rank_method(method):
     def _pass_without_filtering(arr):
         return arr
 
-    method = str(method).casefold()
-    
-    # Select the sort method
+    method = method.lower()
     if method == "inplace":
         ranking_func = _percentile_ranks_numpy_inplace
     elif method == "numpy":


### PR DESCRIPTION

## PR Description

If one wants to use the upsilon correction without the RHEF, they can select "none" as an option. This also implements casefold on the method decision tree and sets the default sorting algorithm to be the scipy rankdata.