### PR TITLE
Fix import for deprecation on scikit-image>0.20

### DIFF
--- a/changelog/321.trivial.rst
+++ b/changelog/321.trivial.rst
@@ -1,0 +1,1 @@
+Update imports in ``stara`` to account for change in scikit-image>0.20.

--- a/pytest.ini
+++ b/pytest.ini
@@ -54,3 +54,4 @@ filterwarnings =
     ignore:leap-second auto-update failed:astropy.utils.exceptions.AstropyWarning
     ignore:.*deprecated - use.*:pyparsing.warnings.PyparsingDeprecationWarning
     ignore:.*argument is deprecated, use.*:pyparsing.warnings.PyparsingDeprecationWarning
+    ignore:`skimage.morphology.white_tophat` is deprecated in favor of:skimage.util.PendingSkimage2Change

--- a/pytest.ini
+++ b/pytest.ini
@@ -54,4 +54,4 @@ filterwarnings =
     ignore:leap-second auto-update failed:astropy.utils.exceptions.AstropyWarning
     ignore:.*deprecated - use.*:pyparsing.warnings.PyparsingDeprecationWarning
     ignore:.*argument is deprecated, use.*:pyparsing.warnings.PyparsingDeprecationWarning
-    ignore:`skimage.morphology.white_tophat` is deprecated in favor of:skimage.util.PendingSkimage2Change
+    ignore:`skimage.morphology.white_tophat` is deprecated in favor of:PendingDeprecationWarning

--- a/sunkit_image/stara.py
+++ b/sunkit_image/stara.py
@@ -1,7 +1,12 @@
 import numpy as np
 import skimage
 from skimage.filters import median
-from skimage.morphology import disk, white_tophat
+try:
+    from skimage.morphology.gray import white_tophat
+    from skimage.morphology import disk
+except ImportError:
+    from skimage.morphology import disk, white_tophat  # remove once scikit-image>0.20
+
 from skimage.util import invert
 
 import astropy.units as u

--- a/sunkit_image/stara.py
+++ b/sunkit_image/stara.py
@@ -6,7 +6,7 @@ try:
     from skimage.morphology import disk
     from skimage.morphology.gray import white_tophat
 except ImportError:
-    from skimage.morphology import disk, white_tophat  # remove once scikit-image>0.20
+    from skimage.morphology import disk  # remove once scikit-image>0.20
 
 from skimage.util import invert
 
@@ -90,7 +90,7 @@ def stara(
     c_pix = int((circle_radius / smap.scale[0]).to_value(u.pix))
     circle = disk(c_pix / 2)
 
-    finite = white_tophat(med, circle)
+    finite = white_tophat(med, circle, mode='reflect')
     finite[np.isnan(finite)] = 0
 
     return finite > threshold

--- a/sunkit_image/stara.py
+++ b/sunkit_image/stara.py
@@ -1,9 +1,10 @@
 import numpy as np
 import skimage
 from skimage.filters import median
+
 try:
-    from skimage.morphology.gray import white_tophat
     from skimage.morphology import disk
+    from skimage.morphology.gray import white_tophat
 except ImportError:
     from skimage.morphology import disk, white_tophat  # remove once scikit-image>0.20
 

--- a/sunkit_image/stara.py
+++ b/sunkit_image/stara.py
@@ -1,12 +1,12 @@
 import numpy as np
 import skimage
 from skimage.filters import median
+from skimage.morphology import disk
 
 try:
-    from skimage.morphology import disk
     from skimage.morphology.gray import white_tophat
 except ImportError:
-    from skimage.morphology import disk  # remove once scikit-image>0.20
+    from skimage.morphology import white_tophat # remove once scikit-image>0.20
 
 from skimage.util import invert
 

--- a/sunkit_image/stara.py
+++ b/sunkit_image/stara.py
@@ -90,7 +90,11 @@ def stara(
     c_pix = int((circle_radius / smap.scale[0]).to_value(u.pix))
     circle = disk(c_pix / 2)
 
-    finite = white_tophat(med, circle, mode='reflect')
+    try:
+        finite = white_tophat(med, circle, mode='reflect')
+    except TypeError:
+        finite = white_tophat(med, circle) # remove when scikit-image>0.20
+
     finite[np.isnan(finite)] = 0
 
     return finite > threshold


### PR DESCRIPTION
## PR Description

Try old import and fail back to new import can be removed once scikit-image>0.20

## AI Assistance Disclosure

AI tools were used for:
- [  ] Code generation (e.g., when writing an implementation or fixing a bug)
- [  ] Test/benchmark generation
- [  ] Documentation (including examples)
- [  ] Research and understanding
- [x ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
